### PR TITLE
Use packages= in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,5 @@ setup(
     "Sunon Cooling Thermostat PWM Tach",
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
-    #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=["adafruit_emc2101"],
+    packages=["adafruit_emc2101"],
 )


### PR DESCRIPTION
This library uses a package folder, but `setup.py` assumed it was a single-file module.