### PR TITLE
Scale fan setting to match `PWM_F`

### DIFF
--- a/adafruit_emc2101/__init__.py
+++ b/adafruit_emc2101/__init__.py
@@ -209,9 +209,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
     """When set to True, the magnitude of the fan output signal is inverted, making 0 the maximum
     value and 100 the minimum value"""
 
-    dac_output_enabled = RWBit(_REG_CONFIG, 4)
-    """When set, the fan control signal is output as a DC voltage instead of a PWM signal"""
-
+    _dac_output_enabled = RWBit(_REG_CONFIG, 4)
     _conversion_rate = RWBits(4, 0x04, 0)
     # fan spin-up
     _spin_drive = RWBits(2, _FAN_SPINUP, 3)
@@ -298,6 +296,16 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         self._fan_lut_prog = True
         self._fan_setting = fan_speed_lsb
         self._fan_lut_prog = lut_disabled
+
+    @property
+    def dac_output_enabled(self):
+        """When set, the fan control signal is output as a DC voltage instead of a PWM signal"""
+        return self._dac_output_enabled
+
+    @dac_output_enabled.setter
+    def dac_output_enabled(self, value):
+        self._dac_output_enabled = value
+        self._calculate_full_speed(dac=value)
 
     @property
     def lut_enabled(self):

--- a/adafruit_emc2101/emc2101_lut.py
+++ b/adafruit_emc2101/emc2101_lut.py
@@ -202,6 +202,7 @@ class EMC2101_LUT(EMC2101):  # pylint: disable=too-many-instance-attributes
         if value < 0 or value > 0x1F:
             raise AttributeError("pwm_frequency must be from 0-31")
         self._pwm_freq = value
+        self._calculate_full_speed(pwm_f=value)
 
     @property
     def pwm_frequency_divisor(self):

--- a/adafruit_emc2101/emc2101_lut.py
+++ b/adafruit_emc2101/emc2101_lut.py
@@ -209,7 +209,7 @@ class EMC2101_LUT(EMC2101):  # pylint: disable=too-many-instance-attributes
     def pwm_frequency(self, value):
         if value < 0 or value > 0x1F:
             raise AttributeError("pwm_frequency must be from 0-31")
-        self._pwm_freq_div = value
+        self._pwm_freq = value
 
     @property
     def pwm_frequency_divisor(self):

--- a/adafruit_emc2101/emc2101_lut.py
+++ b/adafruit_emc2101/emc2101_lut.py
@@ -38,24 +38,15 @@ from micropython import const
 from adafruit_register.i2c_struct_array import StructArray
 from adafruit_register.i2c_struct import UnaryStruct
 from adafruit_register.i2c_bit import RWBit
-from adafruit_register.i2c_bits import RWBits
-from . import EMC2101
+from . import EMC2101, MAX_LUT_SPEED, MAX_LUT_TEMP
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_EMC2101.git"
 
 _FAN_CONFIG = const(0x4A)
-_PWM_FREQ = const(0x4D)
 _PWM_DIV = const(0x4E)
 _LUT_HYSTERESIS = const(0x4F)
 _LUT_BASE = const(0x50)
-
-MAX_LUT_SPEED = 0x3F  # 6-bit value
-MAX_LUT_TEMP = 0x7F  # 7-bit
-
-
-def _speed_to_lsb(percentage):
-    return round((percentage / 100.0) * MAX_LUT_SPEED)
 
 
 class FanSpeedLUT:
@@ -131,7 +122,9 @@ class FanSpeedLUT:
         # we want to assign the lowest temperature to the lowest LUT slot, so we sort the keys/temps
         # get and sort the new lut keys so that we can assign them in order
         for idx, current_temp in enumerate(sorted(self.lut_values.keys())):
-            current_speed = _speed_to_lsb(self.lut_values[current_temp])
+            # We don't want to make `_speed_to_lsb()` public, it is only needed here.
+            # pylint: disable=protected-access
+            current_speed = self.emc_fan._speed_to_lsb(self.lut_values[current_temp])
             self._set_lut_entry(idx, current_temp, current_speed)
 
         # Set the remaining LUT entries to the default (Temp/Speed = max value)
@@ -154,7 +147,6 @@ class EMC2101_LUT(EMC2101):  # pylint: disable=too-many-instance-attributes
 
     _fan_pwm_clock_select = RWBit(_FAN_CONFIG, 3)
     _fan_pwm_clock_override = RWBit(_FAN_CONFIG, 2)
-    _pwm_freq = RWBits(5, _PWM_FREQ, 0)
     _pwm_freq_div = UnaryStruct(_PWM_DIV, "<B")
 
     lut_temperature_hysteresis = UnaryStruct(_LUT_HYSTERESIS, "<B")

--- a/examples/emc2101_set_pwm_freq.py
+++ b/examples/emc2101_set_pwm_freq.py
@@ -10,7 +10,9 @@ i2c = board.I2C()  # uses board.SCL and board.SDA
 emc = EMC2101(i2c)
 emc.set_pwm_clock(use_preset=False)
 # Datasheet recommends using the maximum value of 31 (0x1F)
-# to provide the highest effective resolution
+# to provide the highest effective resolution.
+# The PWM frequency must be set before changing `manual_fan_speed` or LUT entries.
+# Otherwise the PWM duty cycle won't be configured correctly.
 emc.pwm_frequency = 14
 
 # This divides the pwm frequency down to a smaller number


### PR DESCRIPTION
When converting a fan speed percentage to an LSB byte written to the EMC2101 controller, the conversion should translate 100% to 2*PWM_F because the chip determines the PWM duty cycle that way.

The changes in this PR calculate and cache the byte value to use for 100% fan speed in the function `_calculate_full_speed()`. This cached full speed value is recomputed whenever `emc.pwm_frequency` or `emc.dac_output_enabled` are changed — these are the two registers affecting the value.

When setting `emc.manual_fan_speed` or one of the LUT values, the cached full speed value is used to compute the byte to be programmed into the chip. This means that `emc.pwm_frequency` should always be set *before* programming the LUT or manual speed setting.

My new oscilloscope arrived today (yay!), so I was able to test this code by measuring the duty cycle on the FAN pin. I tested 10% fan speed increments both with the default PWM frequency, and with `PWM_F=5` which produces a 35 kHz PWM signal.

![pwm_f5.pdf](https://github.com/adafruit/Adafruit_CircuitPython_EMC2101/files/7447751/pwm_f5.pdf)

Both PWM frequencies plot as a straight line. At 35 kHz, I measured a duty cycle about 0.75% less that the programmed value. I think this is caused by the 1 µs rise time on the open drain FAN pin.
