### PR TITLE
adding get_functions

### DIFF
--- a/adafruit_emc2101/emc2101_ext.py
+++ b/adafruit_emc2101/emc2101_ext.py
@@ -139,13 +139,13 @@ class EMC2101_EXT(EMC2101):  # pylint: disable=too-many-instance-attributes
 
     def __init__(self, i2c_bus):
         super().__init__(i2c_bus)
-        self.initialize()
 
-    def initialize(self):
+        self.emc2101_ext_initialize()
+
+    def emc2101_ext_initialize(self):
         """Reset the controller to an initial default configuration."""
         self.auto_check_status = False
         self._last_status = 0
-        super().initialize()
 
     def _check_status(self):
         if self.auto_check_status:
@@ -201,7 +201,7 @@ class EMC2101_EXT(EMC2101):  # pylint: disable=too-many-instance-attributes
         :return: int temperature in degrees centigrade.
         """
         self._check_status()
-        return super().internal_temperature
+        return self._get_internal_temperature()
 
     @property
     def external_temperature(self):
@@ -218,7 +218,7 @@ class EMC2101_EXT(EMC2101):  # pylint: disable=too-many-instance-attributes
             (not behaving like a diode).
         """
         self._check_status()
-        return super().external_temperature
+        return self._get_external_temperature()
 
     @property
     def fan_speed(self):
@@ -227,7 +227,7 @@ class EMC2101_EXT(EMC2101):  # pylint: disable=too-many-instance-attributes
         :return: float speed in RPM.
         """
         self._check_status()
-        return super().fan_speed
+        return self._get_fan_speed()
 
     @property
     def dev_temp_critical_limit(self):

--- a/adafruit_emc2101/emc2101_lut.py
+++ b/adafruit_emc2101/emc2101_lut.py
@@ -77,7 +77,6 @@ class EMC2101_LUT(EMC2101_EXT):  # pylint: disable=too-many-instance-attributes
         self.lut_enabled = True
         # pylint: disable=attribute-defined-outside-init
         self._fan_clk_ovr = True
-        super().initialize()
         self._check_status()
 
     def set_pwm_clock(self, use_preset=False, use_slow=False):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["adafruit_register"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
closes #27 

For the reviewer:
There are two changes here
1. I have changed the name for each class initialization, due to CircuitPython MRO behaviour, when using the EMC2101_LUT class, and going up to EMC2101 main `__init__ `the call `self.initializate()`there  was calling the `EMC2101_LUT` initialization and not the `EMC2101` one. I guess that is why they were using the `super().initialization` line.. But who knows. This solves the issue when the line below was change to `True`

https://github.com/adafruit/Adafruit_CircuitPython_EMC2101/blob/aea77f5a62ce099c99a35bfe7eae16676dc9fb8b/adafruit_emc2101/emc2101_ext.py#L135

2. I Have changed the property in the parent class to get_xxxxx, to avoid property calling conflicts. 

I have test with the three examples, be aware that, that I could not test the outside_temperature as I do not how to wire it... I did test with a fan. I use a mock up temperature for the tests.  No other changes were made, this PR is solely to solve the issue and no to look further in Library problems

@brody please could you test, thanks :) Hope you have at least a start on how to change the library. Good Luck