### PR TITLE
Fix emc2101_enums import

### DIFF
--- a/adafruit_emc2101/__init__.py
+++ b/adafruit_emc2101/__init__.py
@@ -443,7 +443,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the SpinupDrive is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from emc2101_enums import SpinupDrive
+        from .emc2101_enums import SpinupDrive
 
         if not SpinupDrive.is_valid(spin_drive):
             raise TypeError("spinup_drive must be a SpinupDrive")

--- a/adafruit_emc2101/__init__.py
+++ b/adafruit_emc2101/__init__.py
@@ -410,7 +410,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the SpinupTime is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from .emc2101_enums import SpinupTime
+        from adafruit_emc2101.emc2101_enums import SpinupTime
 
         if not SpinupTime.is_valid(spin_time):
             raise TypeError("spinup_time must be a SpinupTime")
@@ -443,7 +443,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the SpinupDrive is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from .emc2101_enums import SpinupDrive
+        from adafruit_emc2101.emc2101_enums import SpinupDrive
 
         if not SpinupDrive.is_valid(spin_drive):
             raise TypeError("spinup_drive must be a SpinupDrive")
@@ -473,7 +473,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the ConversionRate is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from .emc2101_enums import ConversionRate
+        from adafruit_emc2101.emc2101_enums import ConversionRate
 
         if not ConversionRate.is_valid(rate):
             raise ValueError("conversion_rate must be a `ConversionRate`")

--- a/adafruit_emc2101/__init__.py
+++ b/adafruit_emc2101/__init__.py
@@ -410,7 +410,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the SpinupTime is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from emc2101_enums import SpinupTime
+        from .emc2101_enums import SpinupTime
 
         if not SpinupTime.is_valid(spin_time):
             raise TypeError("spinup_time must be a SpinupTime")
@@ -473,7 +473,7 @@ class EMC2101:  # pylint: disable=too-many-instance-attributes
         # Not importing at top level so the ConversionRate is not loaded
         # unless it is required, and thus 1KB bytecode can be avoided.
         # pylint: disable=import-outside-toplevel
-        from emc2101_enums import ConversionRate
+        from .emc2101_enums import ConversionRate
 
         if not ConversionRate.is_valid(rate):
             raise ValueError("conversion_rate must be a `ConversionRate`")


### PR DESCRIPTION
For #31.

Tested on QT PY RP2040:
```python
Adafruit CircuitPython 8.2.2 on 2023-07-31; Adafruit QT Py RP2040 with rp2040
>>> import board
>>> from adafruit_emc2101 import EMC2101
>>> i2c = board.STEMMA_I2C()
>>> emc = EMC2101(i2c)
>>> emc.spinup_drive
3
>>> emc.spinup_drive = 0
>>> emc.spinup_drive
0
>>> 
```