### PR TITLE
Fix my name, add mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024, Rylie Pavlik
+# SPDX-License-Identifier: Unlicense
+
+Alec Delaney <tekktrik@gmail.com>
+Alec Delaney <tekktrik@gmail.com> <89490472+tekktrik@users.noreply.github.com>
+Alec Delaney <tekktrik@gmail.com> <tekktik@gmail.com>
+Carter Nelson <caternuson@gmail.com>
+Eva Herrada <eva.herrada@adafruit.com>
+Eva Herrada <eva.herrada@adafruit.com> <33632497+dherrada@users.noreply.github.com>
+Eva Herrada <eva.herrada@adafruit.com> <33632497+evaherrada@users.noreply.github.com>
+Eva Herrada <eva.herrada@adafruit.com> <dylan.herrada@adafruit.com>
+Ruth Ivimey-Cook <ruth@ivimey.org>
+Ruth Ivimey-Cook <ruth@ivimey.org> <rivimey@users.noreply.github.com>
+Rylie Pavlik <rylie.pavlik@collabora.com>
+Rylie Pavlik <rylie.pavlik@collabora.com> <rpavlik@iastate.edu>
+Rylie Pavlik <rylie.pavlik@collabora.com> <ryan.pavlik@collabora.com>
+Rylie Pavlik <rylie.pavlik@collabora.com> <ryan.pavlik@gmail.com>
+jposada202020 <jquintana202020@gmail.com>
+jposada202020 <jquintana202020@gmail.com> <34255413+jposada202020@users.noreply.github.com>

--- a/adafruit_emc2101/emc2101_ext.py
+++ b/adafruit_emc2101/emc2101_ext.py
@@ -9,7 +9,7 @@
 Brushless fan controller: extended functionality
 
 
-* Author(s): Bryan Siepert, Ryan Pavlik
+* Author(s): Bryan Siepert, Rylie Pavlik
 
 Implementation Notes
 --------------------

--- a/adafruit_emc2101/emc2101_fanspeed.py
+++ b/adafruit_emc2101/emc2101_fanspeed.py
@@ -9,7 +9,7 @@
 Brushless fan controller: extended functionality
 
 
-* Author(s): Bryan Siepert, Ryan Pavlik
+* Author(s): Bryan Siepert, Rylie Pavlik
 
 Implementation Notes
 --------------------

--- a/adafruit_emc2101/emc2101_lut.py
+++ b/adafruit_emc2101/emc2101_lut.py
@@ -9,7 +9,7 @@
 Brushless fan controller: extended functionality
 
 
-* Author(s): Bryan Siepert, Ryan Pavlik
+* Author(s): Bryan Siepert, Rylie Pavlik
 
 Implementation Notes
 --------------------


### PR DESCRIPTION
My name has been upgraded. I fixed the docs accordingly. In a separate commit, I fixed my committer identity with a mailmap file, taking the opportunity to also clean up other duplicate or typo committer IDs.

No functional change.